### PR TITLE
sigma patch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 3800 Big Chungas Foundation, Inc. <https://bcf.livvydune.ohio.gov/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
commit d05fea77e51c005c97cc9729cbe3b5005ee09a0a
Author: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
Date:   Wed Dec 20 15:32:39 2023 +0100

    Linux 4.14.334
    
    Link: https://lore.kernel.org/r/20231218135040.665690087@linuxfoundation.org
    Tested-by: Pavel Machek (CIP) <pavel@denx.de>                              =
    Tested-by: Harshit Mogalapalli <harshit.m.mogalapalli@oracle.com>
    Tested-by: Linux Kernel Functional Testing <lkft@linaro.org>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 75fbe0d9d54dab4a8a15f562a2405084dba82b98
Author: Naveen N Rao <naveen@kernel.org>
Date:   Fri Dec 15 16:41:22 2023 +0530

    powerpc/ftrace: Fix stack teardown in ftrace_no_trace
    
    commit 4b3338aaa74d7d4ec5b6734dc298f0db94ec83d2 upstream.
    
    Commit 41a506ef71eb ("powerpc/ftrace: Create a dummy stackframe to fix
    stack unwind") added use of a new stack frame on ftrace entry to fix
    stack unwind. However, the commit missed updating the offset used while
    tearing down the ftrace stack when ftrace is disabled. Fix the same.
    
    In addition, the commit missed saving the correct stack pointer in
    pt_regs. Update the same.
    
    Fixes: 41a506ef71eb ("powerpc/ftrace: Create a dummy stackframe to fix stack unwind")
    Cc: stable@vger.kernel.org # v6.5+
    Signed-off-by: Naveen N Rao <naveen@kernel.org>
    Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
    Link: https://msgid.link/20231130065947.2188860-1-naveen@kernel.org
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit ae9be850788d90a91d48221ea8429f4e7b9f14cd
Author: Naveen N Rao <naveen@kernel.org>
Date:   Fri Dec 15 16:41:21 2023 +0530

    powerpc/ftrace: Create a dummy stackframe to fix stack unwind
    
    commit 41a506ef71eb38d94fe133f565c87c3e06ccc072 upstream.
    
    With ppc64 -mprofile-kernel and ppc32 -pg, profiling instructions to
    call into ftrace are emitted right at function entry. The instruction
    sequence used is minimal to reduce overhead. Crucially, a stackframe is
    not created for the function being traced. This breaks stack unwinding
    since the function being traced does not have a stackframe for itself.
    As such, it never shows up in the backtrace:
    
    /sys/kernel/debug/tracing # echo 1 > /proc/sys/kernel/stack_tracer_enabled
    /sys/kernel/debug/tracing # cat stack_trace
            Depth    Size   Location    (17 entries)
            -----    ----   --------
      0)     4144      32   ftrace_call+0x4/0x44
      1)     4112     432   get_page_from_freelist+0x26c/0x1ad0
      2)     3680     496   __alloc_pages+0x290/0x1280
      3)     3184     336   __folio_alloc+0x34/0x90
      4)     2848     176   vma_alloc_folio+0xd8/0x540
      5)     2672     272   __handle_mm_fault+0x700/0x1cc0
      6)     2400     208   handle_mm_fault+0xf0/0x3f0
      7)     2192      80   ___do_page_fault+0x3e4/0xbe0
      8)     2112     160   do_page_fault+0x30/0xc0
      9)     1952     256   data_access_common_virt+0x210/0x220
     10)     1696     400   0xc00000000f16b100
     11)     1296     384   load_elf_binary+0x804/0x1b80
     12)      912     208   bprm_execve+0x2d8/0x7e0
     13)      704      64   do_execveat_common+0x1d0/0x2f0
     14)      640     160   sys_execve+0x54/0x70
     15)      480      64   system_call_exception+0x138/0x350
     16)      416     416   system_call_common+0x160/0x2c4
    
    Fix this by having ftrace create a dummy stackframe for the function
    being traced. With this, backtraces now capture the function being
    traced:
    
    /sys/kernel/debug/tracing # cat stack_trace
            Depth    Size   Location    (17 entries)
            -----    ----   --------
      0)     3888      32   _raw_spin_trylock+0x8/0x70
      1)     3856     576   get_page_from_freelist+0x26c/0x1ad0
      2)     3280      64   __alloc_pages+0x290/0x1280
      3)     3216     336   __folio_alloc+0x34/0x90
      4)     2880     176   vma_alloc_folio+0xd8/0x540
      5)     2704     416   __handle_mm_fault+0x700/0x1cc0
      6)     2288      96   handle_mm_fault+0xf0/0x3f0
      7)     2192      48   ___do_page_fault+0x3e4/0xbe0
      8)     2144     192   do_page_fault+0x30/0xc0
      9)     1952     608   data_access_common_virt+0x210/0x220
     10)     1344      16   0xc0000000334bbb50
     11)     1328     416   load_elf_binary+0x804/0x1b80
     12)      912      64   bprm_execve+0x2d8/0x7e0
     13)      848     176   do_execveat_common+0x1d0/0x2f0
     14)      672     192   sys_execve+0x54/0x70
     15)      480      64   system_call_exception+0x138/0x350
     16)      416     416   system_call_common+0x160/0x2c4
    
    This results in two additional stores in the ftrace entry code, but
    produces reliable backtraces.
    
    Fixes: 153086644fd1 ("powerpc/ftrace: Add support for -mprofile-kernel ftrace ABI")
    Cc: stable@vger.kernel.org
    Signed-off-by: Naveen N Rao <naveen@kernel.org>
    Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
    Link: https://msgid.link/20230621051349.759567-1-naveen@kernel.org
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 321dca2afdc0f131c94704ad189e6a01ec85d192
Author: Steven Rostedt (Google) <rostedt@goodmis.org>
Date:   Sun Dec 10 22:12:50 2023 -0500

    ring-buffer: Fix memory leak of free page
    
    commit 17d801758157bec93f26faaf5ff1a8b9a552d67a upstream.
    
    Reading the ring buffer does a swap of a sub-buffer within the ring buffer
    with a empty sub-buffer. This allows the reader to have full access to the
    content of the sub-buffer that was swapped out without having to worry
    about contention with the writer.
    
    The readers call ring_buffer_alloc_read_page() to allocate a page that
    will be used to swap with the ring buffer. When the code is finished with
    the reader page, it calls ring_buffer_free_read_page(). Instead of freeing
    the page, it stores it as a spare. Then next call to
    ring_buffer_alloc_read_page() will return this spare instead of calling
    into the memory management system to allocate a new page.
    
    Unfortunately, on freeing of the ring buffer, this spare page is not
    freed, and causes a memory leak.
    
    Link: https://lore.kernel.org/linux-trace-kernel/20231210221250.7b9cc83c@rorschach.local.home
    
    Cc: stable@vger.kernel.org
    Cc: Mark Rutland <mark.rutland@arm.com>
    Cc: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
    Fixes: 73a757e63114d ("ring-buffer: Return reader page back into existing ring buffer")
    Acked-by: Masami Hiramatsu (Google) <mhiramat@kernel.org>
    Signed-off-by: Steven Rostedt (Google) <rostedt@goodmis.org>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 4d71b11b02e1295168868977deb9d1e9078e7bec
Author: Florent Revest <revest@chromium.org>
Date:   Wed Dec 6 13:37:18 2023 +0100

    team: Fix use-after-free when an option instance allocation fails
    
    commit c12296bbecc488623b7d1932080e394d08f3226b upstream.
    
    In __team_options_register, team_options are allocated and appended to
    the team's option_list.
    If one option instance allocation fails, the "inst_rollback" cleanup
    path frees the previously allocated options but doesn't remove them from
    the team's option_list.
    This leaves dangling pointers that can be dereferenced later by other
    parts of the team driver that iterate over options.
    
    This patch fixes the cleanup path to remove the dangling pointers from
    the list.
    
    As far as I can tell, this uaf doesn't have much security implications
    since it would be fairly hard to exploit (an attacker would need to make
    the allocation of that specific small object fail) but it's still nice
    to fix.
    
    Cc: stable@vger.kernel.org
    Fixes: 80f7c6683fe0 ("team: add support for per-port options")
    Signed-off-by: Florent Revest <revest@chromium.org>
    Reviewed-by: Jiri Pirko <jiri@nvidia.com>
    Reviewed-by: Hangbin Liu <liuhangbin@gmail.com>
    Link: https://lore.kernel.org/r/20231206123719.1963153-1-revest@chromium.org
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 409b04824eba24e0bc45503a4bdda093794d290d
Author: Baokun Li <libaokun1@huawei.com>
Date:   Mon Nov 27 14:33:13 2023 +0800

    ext4: prevent the normalized size from exceeding EXT_MAX_BLOCKS
    
    commit 2dcf5fde6dffb312a4bfb8ef940cea2d1f402e32 upstream.
    
    For files with logical blocks close to EXT_MAX_BLOCKS, the file size
    predicted in ext4_mb_normalize_request() may exceed EXT_MAX_BLOCKS.
    This can cause some blocks to be preallocated that will not be used.
    And after [Fixes], the following issue may be triggered:
    
    =========================================================
     kernel BUG at fs/ext4/mballoc.c:4653!
     Internal error: Oops - BUG: 00000000f2000800 [#1] SMP
     CPU: 1 PID: 2357 Comm: xfs_io 6.7.0-rc2-00195-g0f5cc96c367f
     Hardware name: linux,dummy-virt (DT)
     pc : ext4_mb_use_inode_pa+0x148/0x208
     lr : ext4_mb_use_inode_pa+0x98/0x208
     Call trace:
      ext4_mb_use_inode_pa+0x148/0x208
      ext4_mb_new_inode_pa+0x240/0x4a8
      ext4_mb_use_best_found+0x1d4/0x208
      ext4_mb_try_best_found+0xc8/0x110
      ext4_mb_regular_allocator+0x11c/0xf48
      ext4_mb_new_blocks+0x790/0xaa8
      ext4_ext_map_blocks+0x7cc/0xd20
      ext4_map_blocks+0x170/0x600
      ext4_iomap_begin+0x1c0/0x348
    =========================================================
    
    Here is a calculation when adjusting ac_b_ex in ext4_mb_new_inode_pa():
    
            ex.fe_logical = orig_goal_end - EXT4_C2B(sbi, ex.fe_len);
            if (ac->ac_o_ex.fe_logical >= ex.fe_logical)
                    goto adjust_bex;
    
    The problem is that when orig_goal_end is subtracted from ac_b_ex.fe_len
    it is still greater than EXT_MAX_BLOCKS, which causes ex.fe_logical to
    overflow to a very small value, which ultimately triggers a BUG_ON in
    ext4_mb_new_inode_pa() because pa->pa_free < len.
    
    The last logical block of an actual write request does not exceed
    EXT_MAX_BLOCKS, so in ext4_mb_normalize_request() also avoids normalizing
    the last logical block to exceed EXT_MAX_BLOCKS to avoid the above issue.
    
    The test case in [Link] can reproduce the above issue with 64k block size.
    
    Link: https://patchwork.kernel.org/project/fstests/list/?series=804003
    Cc:  <stable@kernel.org> # 6.4
    Fixes: 93cdf49f6eca ("ext4: Fix best extent lstart adjustment logic in ext4_mb_new_inode_pa()")
    Signed-off-by: Baokun Li <libaokun1@huawei.com>
    Reviewed-by: Jan Kara <jack@suse.cz>
    Link: https://lore.kernel.org/r/20231127063313.3734294-1-libaokun1@huawei.com
    Signed-off-by: Theodore Ts'o <tytso@mit.edu>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 7327aea5ac3727f9573308a34c22adabc0520436
Author: Denis Benato <benato.denis96@gmail.com>
Date:   Fri Nov 17 14:15:55 2023 +1300

    HID: hid-asus: add const to read-only outgoing usb buffer
    
    [ Upstream commit 06ae5afce8cc1f7621cc5c7751e449ce20d68af7 ]
    
    In the function asus_kbd_set_report the parameter buf is read-only
    as it gets copied in a memory portion suitable for USB transfer,
    but the parameter is not marked as const: add the missing const and mark
    const immutable buffers passed to that function.
    
    Signed-off-by: Denis Benato <benato.denis96@gmail.com>
    Signed-off-by: Luke D. Jones <luke@ljones.dev>
    Signed-off-by: Jiri Kosina <jkosina@suse.cz>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit d55bdeff61b3355c6dead681554c04b1484dd101
Author: Lech Perczak <lech.perczak@gmail.com>
Date:   Sat Nov 18 00:19:18 2023 +0100

    net: usb: qmi_wwan: claim interface 4 for ZTE MF290
    
    [ Upstream commit 99360d9620f09fb8bc15548d855011bbb198c680 ]
    
    Interface 4 is used by for QMI interface in stock firmware of MF28D, the
    router which uses MF290 modem. Rebind it to qmi_wwan after freeing it up
    from option driver.
    The proper configuration is:
    
    Interface mapping is:
    0: QCDM, 1: (unknown), 2: AT (PCUI), 2: AT (Modem), 4: QMI
    
    T:  Bus=01 Lev=02 Prnt=02 Port=00 Cnt=01 Dev#=  4 Spd=480  MxCh= 0
    D:  Ver= 2.00 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
    P:  Vendor=19d2 ProdID=0189 Rev= 0.00
    S:  Manufacturer=ZTE, Incorporated
    S:  Product=ZTE LTE Technologies MSM
    C:* #Ifs= 5 Cfg#= 1 Atr=e0 MxPwr=500mA
    I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
    E:  Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
    E:  Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=4ms
    I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
    E:  Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
    E:  Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=4ms
    I:* If#= 2 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
    E:  Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
    E:  Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=4ms
    I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
    E:  Ad=84(I) Atr=03(Int.) MxPS=  64 Ivl=2ms
    E:  Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
    E:  Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=4ms
    I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
    E:  Ad=86(I) Atr=03(Int.) MxPS=  64 Ivl=2ms
    E:  Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
    E:  Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=4ms
    
    Cc: BjÃ¸rn Mork <bjorn@mork.no>
    Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
    Link: https://lore.kernel.org/r/20231117231918.100278-3-lech.perczak@gmail.com
    Signed-off-by: Paolo Abeni <pabeni@redhat.com>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 894076cde78f36ed776ab1b19e860b28adb47e14
Author: Linus Torvalds <torvalds@linux-foundation.org>
Date:   Thu Nov 9 22:22:13 2023 -0800

    asm-generic: qspinlock: fix queued_spin_value_unlocked() implementation
    
    [ Upstream commit 125b0bb95dd6bec81b806b997a4ccb026eeecf8f ]
    
    We really don't want to do atomic_read() or anything like that, since we
    already have the value, not the lock.  The whole point of this is that
    we've loaded the lock from memory, and we want to check whether the
    value we loaded was a locked one or not.
    
    The main use of this is the lockref code, which loads both the lock and
    the reference count in one atomic operation, and then works on that
    combined value.  With the atomic_read(), the compiler would pointlessly
    spill the value to the stack, in order to then be able to read it back
    "atomically".
    
    This is the qspinlock version of commit c6f4a9002252 ("asm-generic:
    ticket-lock: Optimize arch_spin_value_unlocked()") which fixed this same
    bug for ticket locks.
    
    Cc: Guo Ren <guoren@kernel.org>
    Cc: Ingo Molnar <mingo@kernel.org>
    Cc: Waiman Long <longman@redhat.com>
    Link: https://lore.kernel.org/all/CAHk-=whNRv0v6kQiV5QO6DJhjH4KEL36vWQ6Re8Csrnh4zbRkQ@mail.gmail.com/
    Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit badebd9ba26f8129c6dfb672a7d8b58486e7622a
Author: Aoba K <nexp_0x17@outlook.com>
Date:   Tue Nov 21 20:23:11 2023 +0800

    HID: multitouch: Add quirk for HONOR GLO-GXXX touchpad
    
    [ Upstream commit 9ffccb691adb854e7b7f3ee57fbbda12ff70533f ]
    
    Honor MagicBook 13 2023 has a touchpad which do not switch to the multitouch
    mode until the input mode feature is written by the host.  The touchpad do
    report the input mode at touchpad(3), while itself working under mouse mode. As
    a workaround, it is possible to call MT_QUIRE_FORCE_GET_FEATURE to force set
    feature in mt_set_input_mode for such device.
    
    The touchpad reports as BLTP7853, which cannot retrive any useful manufacture
    information on the internel by this string at present.  As the serial number of
    the laptop is GLO-G52, while DMI info reports the laptop serial number as
    GLO-GXXX, this workaround should applied to all models which has the GLO-GXXX.
    
    Signed-off-by: Aoba K <nexp_0x17@outlook.com>
    Signed-off-by: Jiri Kosina <jkosina@suse.cz>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit c26478982d74a47dfb1d2ffb61f04547934a3177
Author: Denis Benato <benato.denis96@gmail.com>
Date:   Fri Nov 17 14:15:56 2023 +1300

    HID: hid-asus: reset the backlight brightness level on resume
    
    [ Upstream commit 546edbd26cff7ae990e480a59150e801a06f77b1 ]
    
    Some devices managed by this driver automatically set brightness to 0
    before entering a suspended state and reset it back to a default
    brightness level after the resume:
    this has the effect of having the kernel report wrong brightness
    status after a sleep, and on some devices (like the Asus RC71L) that
    brightness is the intensity of LEDs directly facing the user.
    
    Fix the above issue by setting back brightness to the level it had
    before entering a sleep state.
    
    Signed-off-by: Denis Benato <benato.denis96@gmail.com>
    Signed-off-by: Luke D. Jones <luke@ljones.dev>
    Signed-off-by: Jiri Kosina <jkosina@suse.cz>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 4851cdd83e57e15b48ebbf6b36430a9a2c532b95
Author: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
Date:   Mon Nov 20 17:07:56 2023 +0200

    platform/x86: intel_telemetry: Fix kernel doc descriptions
    
    [ Upstream commit a6584711e64d9d12ab79a450ec3628fd35e4f476 ]
    
    LKP found issues with a kernel doc in the driver:
    
    core.c:116: warning: Function parameter or member 'ioss_evtconfig' not described in 'telemetry_update_events'
    core.c:188: warning: Function parameter or member 'ioss_evtconfig' not described in 'telemetry_get_eventconfig'
    
    It looks like it were copy'n'paste typos when these descriptions
    had been introduced. Fix the typos.
    
    Reported-by: kernel test robot <lkp@intel.com>
    Closes: https://lore.kernel.org/oe-kbuild-all/202310070743.WALmRGSY-lkp@intel.com/
    Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
    Link: https://lore.kernel.org/r/20231120150756.1661425-1-andriy.shevchenko@linux.intel.com
    Reviewed-by: Rajneesh Bhardwaj <irenic.rajneesh@gmail.com>
    Reviewed-by: Ilpo JÃ¤rvinen <ilpo.jarvinen@linux.intel.com>
    Signed-off-by: Ilpo JÃ¤rvinen <ilpo.jarvinen@linux.intel.com>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 049d7fb74f871fdb46630381eb5016ebc8ad8bbd
Author: Coly Li <colyli@suse.de>
Date:   Mon Nov 20 13:25:02 2023 +0800

    bcache: add code comments for bch_btree_node_get() and __bch_btree_node_alloc()
    
    [ Upstream commit 31f5b956a197d4ec25c8a07cb3a2ab69d0c0b82f ]
    
    This patch adds code comments to bch_btree_node_get() and
    __bch_btree_node_alloc() that NULL pointer will not be returned and it
    is unnecessary to check NULL pointer by the callers of these routines.
    
    Signed-off-by: Coly Li <colyli@suse.de>
    Link: https://lore.kernel.org/r/20231120052503.6122-10-colyli@suse.de
    Signed-off-by: Jens Axboe <axboe@kernel.dk>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit a02316281851200b2e77adf42311075413afad72
Author: Ming Lei <ming.lei@redhat.com>
Date:   Fri Nov 17 10:35:22 2023 +0800

    blk-throttle: fix lockdep warning of "cgroup_mutex or RCU read lock required!"
    
    [ Upstream commit 27b13e209ddca5979847a1b57890e0372c1edcee ]
    
    Inside blkg_for_each_descendant_pre(), both
    css_for_each_descendant_pre() and blkg_lookup() requires RCU read lock,
    and either cgroup_assert_mutex_or_rcu_locked() or rcu_read_lock_held()
    is called.
    
    Fix the warning by adding rcu read lock.
    
    Reported-by: Changhui Zhong <czhong@redhat.com>
    Signed-off-by: Ming Lei <ming.lei@redhat.com>
    Link: https://lore.kernel.org/r/20231117023527.3188627-2-ming.lei@redhat.com
    Signed-off-by: Jens Axboe <axboe@kernel.dk>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit eac54659ff77706569a8419510ca6676b6ff9827
Author: Jens Axboe <axboe@kernel.dk>
Date:   Fri Dec 15 13:24:10 2023 -0700

    cred: switch to using atomic_long_t
    
    commit f8fa5d76925991976b3e7076f9d1052515ec1fca upstream.
    
    There are multiple ways to grab references to credentials, and the only
    protection we have against overflowing it is the memory required to do
    so.
    
    With memory sizes only moving in one direction, let's bump the reference
    count to 64-bit and move it outside the realm of feasibly overflowing.
    
    Signed-off-by: Jens Axboe <axboe@kernel.dk>
    Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
    Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>

commit 0686da1ada51c787610185de6289d8a5006ad263
Author: Hyunwoo Kim <v4bel@theori.io>
Date:   Tue Dec 12 23:10:56 2023 -0500

    appletalk: Fix Use-After-Free in atalk_ioctl
    
    [ Upstream commit 189ff16722ee36ced4d2a2469d4ab65a8fee4198 ]
    
    Because atalk_ioctl() accesses sk->sk_receive_queue
    without holding a sk->sk_receive_queue.lock, it can
    cause a race with atalk_recvmsg().
    A use-after-free for skb occurs with the following flow.
    ```
    atalk_ioctl() -> skb_peek()
    atalk_recvmsg() -> skb_recv_datagram() -> skb_free_datagram()
    ```
    Add sk->sk_receive_queue.lock to atalk_ioctl() to fix this issue.
    
    Fixes: 1da177e4c3f4 ("Linux-2.6.12-rc2")
    Signed-off-by: Hyunwoo Kim <v4bel@theori.io>
    Link: https://lore.kernel.org/r/20231213041056.GA519680@v4bel-B760M-AORUS-ELITE-AX
    Signed-off-by: Paolo Abeni <pabeni@redhat.com>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit ad2ecbdc29909424cc34b7383faf8a7c7585cf52
Author: Nikolay Kuratov <kniv@yandex-team.ru>
Date:   Mon Dec 11 19:23:17 2023 +0300

    vsock/virtio: Fix unsigned integer wrap around in virtio_transport_has_space()
    
    [ Upstream commit 60316d7f10b17a7ebb1ead0642fee8710e1560e0 ]
    
    We need to do signed arithmetic if we expect condition
    `if (bytes < 0)` to be possible
    
    Found by Linux Verification Center (linuxtesting.org) with SVACE
    
    Fixes: 06a8fc78367d ("VSOCK: Introduce virtio_vsock_common.ko")
    Signed-off-by: Nikolay Kuratov <kniv@yandex-team.ru>
    Reviewed-by: Stefano Garzarella <sgarzare@redhat.com>
    Link: https://lore.kernel.org/r/20231211162317.4116625-1-kniv@yandex-team.ru
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 1a455a1ddb0b77a6118f001f1d397bd2edc87e06
Author: Yusong Gao <a869920004@gmail.com>
Date:   Wed Dec 13 10:31:10 2023 +0000

    sign-file: Fix incorrect return values check
    
    [ Upstream commit 829649443e78d85db0cff0c37cadb28fbb1a5f6f ]
    
    There are some wrong return values check in sign-file when call OpenSSL
    API. The ERR() check cond is wrong because of the program only check the
    return value is < 0 which ignored the return val is 0. For example:
    1. CMS_final() return 1 for success or 0 for failure.
    2. i2d_CMS_bio_stream() returns 1 for success or 0 for failure.
    3. i2d_TYPEbio() return 1 for success and 0 for failure.
    4. BIO_free() return 1 for success and 0 for failure.
    
    Link: https://www.openssl.org/docs/manmaster/man3/
    Fixes: e5a2e3c84782 ("scripts/sign-file.c: Add support for signing with a raw signature")
    Signed-off-by: Yusong Gao <a869920004@gmail.com>
    Reviewed-by: Juerg Haefliger <juerg.haefliger@canonical.com>
    Signed-off-by: David Howells <dhowells@redhat.com>
    Link: https://lore.kernel.org/r/20231213024405.624692-1-a869920004@gmail.com/ # v5
    Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit e71c332bcf3f2b80ecdb1af03535b7ed6895ece1
Author: Dong Chenchen <dongchenchen2@huawei.com>
Date:   Sun Dec 10 10:02:00 2023 +0800

    net: Remove acked SYN flag from packet in the transmit queue correctly
    
    [ Upstream commit f99cd56230f56c8b6b33713c5be4da5d6766be1f ]
    
    syzkaller report:
    
     kernel BUG at net/core/skbuff.c:3452!
     invalid opcode: 0000 [#1] PREEMPT SMP KASAN PTI
     CPU: 0 PID: 0 Comm: swapper/0 Not tainted 6.7.0-rc4-00009-gbee0e7762ad2-dirty #135
     RIP: 0010:skb_copy_and_csum_bits (net/core/skbuff.c:3452)
     Call Trace:
     icmp_glue_bits (net/ipv4/icmp.c:357)
     __ip_append_data.isra.0 (net/ipv4/ip_output.c:1165)
     ip_append_data (net/ipv4/ip_output.c:1362 net/ipv4/ip_output.c:1341)
     icmp_push_reply (net/ipv4/icmp.c:370)
     __icmp_send (./include/net/route.h:252 net/ipv4/icmp.c:772)
     ip_fragment.constprop.0 (./include/linux/skbuff.h:1234 net/ipv4/ip_output.c:592 net/ipv4/ip_output.c:577)
     __ip_finish_output (net/ipv4/ip_output.c:311 net/ipv4/ip_output.c:295)
     ip_output (net/ipv4/ip_output.c:427)
     __ip_queue_xmit (net/ipv4/ip_output.c:535)
     __tcp_transmit_skb (net/ipv4/tcp_output.c:1462)
     __tcp_retransmit_skb (net/ipv4/tcp_output.c:3387)
     tcp_retransmit_skb (net/ipv4/tcp_output.c:3404)
     tcp_retransmit_timer (net/ipv4/tcp_timer.c:604)
     tcp_write_timer (./include/linux/spinlock.h:391 net/ipv4/tcp_timer.c:716)
    
    The panic issue was trigered by tcp simultaneous initiation.
    The initiation process is as follows:
    
          TCP A                                            TCP B
    
      1.  CLOSED                                           CLOSED
    
      2.  SYN-SENT     --> <SEQ=100><CTL=SYN>              ...
    
      3.  SYN-RECEIVED <-- <SEQ=300><CTL=SYN>              <-- SYN-SENT
    
      4.               ... <SEQ=100><CTL=SYN>              --> SYN-RECEIVED
    
      5.  SYN-RECEIVED --> <SEQ=100><ACK=301><CTL=SYN,ACK> ...
    
      // TCP B: not send challenge ack for ack limit or packet loss
      // TCP A: close
            tcp_close
               tcp_send_fin
                  if (!tskb && tcp_under_memory_pressure(sk))
                      tskb = skb_rb_last(&sk->tcp_rtx_queue); //pick SYN_ACK packet
               TCP_SKB_CB(tskb)->tcp_flags |= TCPHDR_FIN;  // set FIN flag
    
      6.  FIN_WAIT_1  --> <SEQ=100><ACK=301><END_SEQ=102><CTL=SYN,FIN,ACK> ...
    
      // TCP B: send challenge ack to SYN_FIN_ACK
    
      7.               ... <SEQ=301><ACK=101><CTL=ACK>   <-- SYN-RECEIVED //challenge ack
    
      // TCP A:  <SND.UNA=101>
    
      8.  FIN_WAIT_1 --> <SEQ=101><ACK=301><END_SEQ=102><CTL=SYN,FIN,ACK> ... // retransmit panic
    
            __tcp_retransmit_skb  //skb->len=0
                tcp_trim_head
                    len = tp->snd_una - TCP_SKB_CB(skb)->seq // len=101-100
                        __pskb_trim_head
                            skb->data_len -= len // skb->len=-1, wrap around
                ... ...
                ip_fragment
                    icmp_glue_bits //BUG_ON
    
    If we use tcp_trim_head() to remove acked SYN from packet that contains data
    or other flags, skb->len will be incorrectly decremented. We can remove SYN
    flag that has been acked from rtx_queue earlier than tcp_trim_head(), which
    can fix the problem mentioned above.
    
    Fixes: 1da177e4c3f4 ("Linux-2.6.12-rc2")
    Co-developed-by: Eric Dumazet <edumazet@google.com>
    Signed-off-by: Eric Dumazet <edumazet@google.com>
    Signed-off-by: Dong Chenchen <dongchenchen2@huawei.com>
    Link: https://lore.kernel.org/r/20231210020200.1539875-1-dongchenchen2@huawei.com
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit eb2105fb9dd6fdca42cba3d36aa6ba37f1eb5cdf
Author: Dinghao Liu <dinghao.liu@zju.edu.cn>
Date:   Sun Dec 10 12:52:55 2023 +0800

    qed: Fix a potential use-after-free in qed_cxt_tables_alloc
    
    [ Upstream commit b65d52ac9c085c0c52dee012a210d4e2f352611b ]
    
    qed_ilt_shadow_alloc() will call qed_ilt_shadow_free() to
    free p_hwfn->p_cxt_mngr->ilt_shadow on error. However,
    qed_cxt_tables_alloc() accesses the freed pointer on failure
    of qed_ilt_shadow_alloc() through calling qed_cxt_mngr_free(),
    which may lead to use-after-free. Fix this issue by setting
    p_mngr->ilt_shadow to NULL in qed_ilt_shadow_free().
    
    Fixes: fe56b9e6a8d9 ("qed: Add module with basic common support")
    Reviewed-by: Przemek Kitszel <przemyslaw.kitszel@intel.com>
    Signed-off-by: Dinghao Liu <dinghao.liu@zju.edu.cn>
    Link: https://lore.kernel.org/r/20231210045255.21383-1-dinghao.liu@zju.edu.cn
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 02af3c8ab5cda2633b187bd18b5dc2b9f0af0859
Author: Hyunwoo Kim <v4bel@theori.io>
Date:   Sat Dec 9 05:05:38 2023 -0500

    net/rose: Fix Use-After-Free in rose_ioctl
    
    [ Upstream commit 810c38a369a0a0ce625b5c12169abce1dd9ccd53 ]
    
    Because rose_ioctl() accesses sk->sk_receive_queue
    without holding a sk->sk_receive_queue.lock, it can
    cause a race with rose_accept().
    A use-after-free for skb occurs with the following flow.
    ```
    rose_ioctl() -> skb_peek()
    rose_accept() -> skb_dequeue() -> kfree_skb()
    ```
    Add sk->sk_receive_queue.lock to rose_ioctl() to fix this issue.
    
    Fixes: 1da177e4c3f4 ("Linux-2.6.12-rc2")
    Signed-off-by: Hyunwoo Kim <v4bel@theori.io>
    Link: https://lore.kernel.org/r/20231209100538.GA407321@v4bel-B760M-AORUS-ELITE-AX
    Signed-off-by: Paolo Abeni <pabeni@redhat.com>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 3ddeb55deec5e0e324d0ab8cc2ddd528518ea12d
Author: Hyunwoo Kim <v4bel@theori.io>
Date:   Sat Dec 9 04:42:10 2023 -0500

    atm: Fix Use-After-Free in do_vcc_ioctl
    
    [ Upstream commit 24e90b9e34f9e039f56b5f25f6e6eb92cdd8f4b3 ]
    
    Because do_vcc_ioctl() accesses sk->sk_receive_queue
    without holding a sk->sk_receive_queue.lock, it can
    cause a race with vcc_recvmsg().
    A use-after-free for skb occurs with the following flow.
    ```
    do_vcc_ioctl() -> skb_peek()
    vcc_recvmsg() -> skb_recv_datagram() -> skb_free_datagram()
    ```
    Add sk->sk_receive_queue.lock to do_vcc_ioctl() to fix this issue.
    
    Fixes: 1da177e4c3f4 ("Linux-2.6.12-rc2")
    Signed-off-by: Hyunwoo Kim <v4bel@theori.io>
    Link: https://lore.kernel.org/r/20231209094210.GA403126@v4bel-B760M-AORUS-ELITE-AX
    Signed-off-by: Paolo Abeni <pabeni@redhat.com>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 9e8551648a456e5a14a9353c9c45d224a8f28e90
Author: Chengfeng Ye <dg573847474@gmail.com>
Date:   Thu Dec 7 12:34:53 2023 +0000

    atm: solos-pci: Fix potential deadlock on &tx_queue_lock
    
    [ Upstream commit 15319a4e8ee4b098118591c6ccbd17237f841613 ]
    
    As &card->tx_queue_lock is acquired under softirq context along the
    following call chain from solos_bh(), other acquisition of the same
    lock inside process context should disable at least bh to avoid double
    lock.
    
    <deadlock #2>
    pclose()
    --> spin_lock(&card->tx_queue_lock)
    <interrupt>
       --> solos_bh()
       --> fpga_tx()
       --> spin_lock(&card->tx_queue_lock)
    
    This flaw was found by an experimental static analysis tool I am
    developing for irq-related deadlock.
    
    To prevent the potential deadlock, the patch uses spin_lock_bh()
    on &card->tx_queue_lock under process context code consistently to
    prevent the possible deadlock scenario.
    
    Fixes: 213e85d38912 ("solos-pci: clean up pclose() function")
    Signed-off-by: Chengfeng Ye <dg573847474@gmail.com>
    Signed-off-by: David S. Miller <davem@davemloft.net>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit a918d0cd5bb647233a4f70815cfe17af97285edb
Author: Chengfeng Ye <dg573847474@gmail.com>
Date:   Thu Dec 7 12:34:37 2023 +0000

    atm: solos-pci: Fix potential deadlock on &cli_queue_lock
    
    [ Upstream commit d5dba32b8f6cb39be708b726044ba30dbc088b30 ]
    
    As &card->cli_queue_lock is acquired under softirq context along the
    following call chain from solos_bh(), other acquisition of the same
    lock inside process context should disable at least bh to avoid double
    lock.
    
    <deadlock #1>
    console_show()
    --> spin_lock(&card->cli_queue_lock)
    <interrupt>
       --> solos_bh()
       --> spin_lock(&card->cli_queue_lock)
    
    This flaw was found by an experimental static analysis tool I am
    developing for irq-related deadlock.
    
    To prevent the potential deadlock, the patch uses spin_lock_bh()
    on the card->cli_queue_lock under process context code consistently
    to prevent the possible deadlock scenario.
    
    Fixes: 9c54004ea717 ("atm: Driver for Solos PCI ADSL2+ card.")
    Signed-off-by: Chengfeng Ye <dg573847474@gmail.com>
    Signed-off-by: David S. Miller <davem@davemloft.net>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit eebab1f60a49168714cc3c6d078b7c6cb440a2c9
Author: Stefan Wahren <wahrenst@gmx.net>
Date:   Wed Dec 6 15:12:22 2023 +0100

    qca_spi: Fix reset behavior
    
    [ Upstream commit 1057812d146dd658c9a9a96d869c2551150207b5 ]
    
    In case of a reset triggered by the QCA7000 itself, the behavior of the
    qca_spi driver was not quite correct:
    - in case of a pending RX frame decoding the drop counter must be
      incremented and decoding state machine reseted
    - also the reset counter must always be incremented regardless of sync
      state
    
    Fixes: 291ab06ecf67 ("net: qualcomm: new Ethernet over SPI driver for QCA7000")
    Signed-off-by: Stefan Wahren <wahrenst@gmx.net>
    Link: https://lore.kernel.org/r/20231206141222.52029-4-wahrenst@gmx.net
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 2a765dc4a7f013f57c12cae7118be6d74dd32969
Author: Stefan Wahren <wahrenst@gmx.net>
Date:   Wed Dec 6 15:12:21 2023 +0100

    qca_debug: Fix ethtool -G iface tx behavior
    
    [ Upstream commit 96a7e861d9e04d07febd3011c30cd84cd141d81f ]
    
    After calling ethtool -g it was not possible to adjust the TX ring
    size again:
    
      # ethtool -g eth1
      Ring parameters for eth1:
      Pre-set maximums:
      RX:           4
      RX Mini:      n/a
      RX Jumbo:     n/a
      TX:           10
      Current hardware settings:
      RX:           4
      RX Mini:      n/a
      RX Jumbo:     n/a
      TX:           10
      # ethtool -G eth1 tx 8
      netlink error: Invalid argument
    
    The reason for this is that the readonly setting rx_pending get
    initialized and after that the range check in qcaspi_set_ringparam()
    fails regardless of the provided parameter. So fix this by accepting
    the exposed RX defaults. Instead of adding another magic number
    better use a new define here.
    
    Fixes: 291ab06ecf67 ("net: qualcomm: new Ethernet over SPI driver for QCA7000")
    Suggested-by: Paolo Abeni <pabeni@redhat.com>
    Signed-off-by: Stefan Wahren <wahrenst@gmx.net>
    Link: https://lore.kernel.org/r/20231206141222.52029-3-wahrenst@gmx.net
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>

commit 86aa2245dfc9cc6ebcd5a7987646895167edbb63
Author: Stefan Wahren <wahrenst@gmx.net>
Date:   Wed Dec 6 15:12:20 2023 +0100

    qca_debug: Prevent crash on TX ring changes
    
    [ Upstream commit f4e6064c97c050bd9904925ff7d53d0c9954fc7b ]
    
    The qca_spi driver stop and restart the SPI kernel thread
    (via ndo_stop & ndo_open) in case of TX ring changes. This is
    a big issue because it allows userspace to prevent restart of
    the SPI kernel thread (via signals). A subsequent change of
    TX ring wrongly assume a valid spi_thread pointer which result
    in a crash.
    
    So prevent this by stopping the network traffic handling and
    temporary park the SPI thread.
    
    Fixes: 291ab06ecf67 ("net: qualcomm: new Ethernet over SPI driver for QCA7000")
    Signed-off-by: Stefan Wahren <wahrenst@gmx.net>
    Link: https://lore.kernel.org/r/20231206141222.52029-2-wahrenst@gmx.net
    Signed-off-by: Jakub Kicinski <kuba@kernel.org>
    Signed-off-by: Sasha Levin <sashal@kernel.org>